### PR TITLE
Fix titlebar text with custom font settings

### DIFF
--- a/plastik-for-qubes/kwin-client/plastikclient.cpp
+++ b/plastik-for-qubes/kwin-client/plastikclient.cpp
@@ -603,6 +603,7 @@ const QPixmap &PlastikClient::captionPixmap() const
     painter.drawTiledPixmap(captionPixmap->rect(),
                             Handler()->pixmap(qubes_label, TitleBarTile, active, isToolWindow()) );
 
+    painter.setFont(s_vmnameFont);
     QRect boundingRect1 = painter.boundingRect(captionPixmap->rect(),
                                               Qt::AlignVCenter | Qt::AlignLeft, qubes_vmname);
 


### PR DESCRIPTION
Setting a very large titlebar text font (try with size 128 to see it clearly) results in the upper part of the text being cut off.

This is because the code fails to set the proper font before asking for the text bounding rect.

It's still not perfectly centered vertically at huge sizes but at least it's now properly displayed.
